### PR TITLE
[Issue #62]: ImageServer distribution paths collide

### DIFF
--- a/ImageServer/ImageServer.proj
+++ b/ImageServer/ImageServer.proj
@@ -49,8 +49,8 @@
   <Choose>
     <When Condition="$(DistributionBuild)">
       <PropertyGroup>
-        <DeploymentOutputPath>..\Distribution\Build\ImageServer$(BuildSuffix)\$(PlatformSubFolder)\$(Configuration)\Web</DeploymentOutputPath>
-        <DistributionDir>$(MSBuildProjectDirectory)\$(DeploymentOutputPath)</DistributionDir>
+		<DistributionDir>$(MSBuildProjectDirectory)\..\Distribution\Build\ImageServer$(BuildSuffix)\$(PlatformSubFolder)\$(Configuration)</DistributionDir>
+        <DeploymentOutputPath>..\Distribution\Build\ImageServer$(BuildSuffix)\$(PlatformSubFolder)\$(Configuration)\web</DeploymentOutputPath>
       </PropertyGroup>
     </When>
     <Otherwise>


### PR DESCRIPTION
Fixes issue #62

When building ImageServer.proj all files are put into the distribution folder reserved for the Web GUI:

\Distribution\Build\ImageServer_Community\x64\Release\Web

since 

$(DistributionDir)

and 

$(DeploymentOutputPath)

point to this same path.

The proposed changes affect the PostBuild event of
- ClearCanvas.ImageServer.Executable.csproj
- ClearCanvas.ImageServer.ShredHostService.csproj
  which now put their files into

\Distribution\Build\ImageServer_Community\x64\Release

and as before, the Web GUI coming from WebApplicationDeployment.wdproj ends up in

\Distribution\Build\ImageServer_Community\x64\Release\web

I hope I am on the wright path and could contribute a little!
Thank you!
