### PR TITLE
Update SharpZipWriter.cs to get non-empty zip files

### DIFF
--- a/ImageServer/Core/SharpZipLib/SharpZipWriter.cs
+++ b/ImageServer/Core/SharpZipLib/SharpZipWriter.cs
@@ -125,10 +125,8 @@ namespace ClearCanvas.ImageServer.Core.SharpZipLib
 
         public void AddFileStream(string directoryPathInArchive, Stream sourceFile, string comment)
         {
+            sourceFile.Position = 0;
             _zipFile.Add(new FileStreamDataSource(sourceFile), directoryPathInArchive, ForceCompress ? CompressionMethod.Deflated : CompressionMethod.Stored);
-
-            var entry = _zipFile.GetEntry(directoryPathInArchive);
-            entry.Comment = comment;
         }
 
         public void AddDirectory(string sourceDirectory)


### PR DESCRIPTION
"Archive Application Log" Service creates empty zip files on the filesystem due to:
- entry being null
  _zipFile hasnt been updated with _zipFile.CommitUpdate() yet. Exception "Cannot find central directory" is then thrown by setting entry.Comment
- MemoryStream sourceFile.Position being at its end
  thus sourceFile.Read(buffer, 0, readSize) returns 0 Bytes and nothing is written into the ApplicationLog zipfile. Exception "Failed to copy bytes expected xx read 0" is thrown by _zipFile.CommitUpdate() at ICSharpCode.SharpZipLib.Zip.ZipFile.CopyBytes
