### PR TITLE
Rewrite GenerateUID to use a custom method rather than depend on System.Numerics

### DIFF
--- a/Dicom/DicomUid.cs
+++ b/Dicom/DicomUid.cs
@@ -273,6 +273,10 @@ namespace ClearCanvas.Dicom
             }
         }
 
+    // The following method was contributed by Peter O. and
+    // is released to the public domain.  It can also be
+    // found at:
+    // <https://gist.github.com/peteroupc/c55d330d72c51d267eb4>  
     public static string GuidToDecimalString(Guid guid) {
       byte[] bytes = guid.ToByteArray();
       int[] tempReg = new int[8];


### PR DESCRIPTION
This custom method I wrote removes the dependency on System.Numerics and its BigInteger class, as suggested at https://github.com/jasper-yeh/ClearCanvas/issues/22.  I release this method to the public domain; the method can also be found at: https://gist.github.com/peteroupc/c55d330d72c51d267eb4.
