### PR TITLE
Update StreamReader.cs - Unable to view PT studies due to null pointe…

### DIFF
--- a/Dicom/IO/StreamReader.cs
+++ b/Dicom/IO/StreamReader.cs
@@ -729,7 +729,7 @@ namespace ClearCanvas.Dicom.IO
 											if (Flags.IsSet(options, DicomReadOptions.KeepGroupLengths))
 												ds[LastTagRead] = elem;
 										}
-										else
+										else if (ds != null)
 											ds[LastTagRead] = elem;
 
 										if (rec.Curlen != _undefinedLength)
@@ -762,7 +762,7 @@ namespace ClearCanvas.Dicom.IO
 											if (Flags.IsSet(options, DicomReadOptions.KeepGroupLengths))
 												Dataset[LastTagRead] = elem;
 										}
-										else
+										else if (ds != null)
 											Dataset[LastTagRead] = elem;
 									}
 								}

--- a/Dicom/IO/StreamReader.cs
+++ b/Dicom/IO/StreamReader.cs
@@ -762,7 +762,7 @@ namespace ClearCanvas.Dicom.IO
 											if (Flags.IsSet(options, DicomReadOptions.KeepGroupLengths))
 												Dataset[LastTagRead] = elem;
 										}
-										else if (ds != null)
+										else
 											Dataset[LastTagRead] = elem;
 									}
 								}


### PR DESCRIPTION
…r exception.

Some PT studies are unparseable and unviewable with ClearCanvas due to null pointer exception that is thrown at the following code line.

Current Code:
                                        if (LastTagRead.Element == 0x0000)
                                        {
                                            if (Flags.IsSet(options, DicomReadOptions.KeepGroupLengths))
                                                ds[LastTagRead] = elem;
                                        }
                                        else
                                        {
                                            ds[LastTagRead] = elem;
                                        }

Proposed Code Change:
                                        if (LastTagRead.Element == 0x0000)
                                        {
                                            if (Flags.IsSet(options, DicomReadOptions.KeepGroupLengths))
                                                ds[LastTagRead] = elem;
                                        }
                                        else if (ds != null)
                                        {
                                            ds[LastTagRead] = elem;
                                        }
